### PR TITLE
feat: Report APIs Entities

### DIFF
--- a/src/main/java/dev/joelfrancisco/abp/entities/Group.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/Group.java
@@ -13,6 +13,9 @@ public class Group extends BaseEntity {
     private UUID groupId;
     @Column(name = "name")
     private String name;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private Set<Recipient> recipients = new HashSet<>();
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)

--- a/src/main/java/dev/joelfrancisco/abp/entities/Group.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/Group.java
@@ -1,0 +1,54 @@
+package dev.joelfrancisco.abp.entities;
+
+import jakarta.persistence.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+public class Group extends BaseEntity {
+    @OneToMany
+    @Column(name = "group_id")
+    private UUID groupId;
+    @Column(name = "name")
+    private String name;
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
+    private Set<Recipient> recipients = new HashSet<>();
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
+    private Set<Report> reports = new HashSet<>();
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
+    private Set<SentEmail> sentEmails = new HashSet<>();
+
+    public Group(String name) {
+        super();
+        setName(name);
+    }
+
+    protected Group() {
+    }
+
+    public UUID getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(UUID groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Recipient> getRecipients() {
+        return recipients;
+    }
+
+    public void setRecipients(Set<Recipient> recipients) {
+        this.recipients = recipients;
+    }
+}

--- a/src/main/java/dev/joelfrancisco/abp/entities/Recipient.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/Recipient.java
@@ -11,6 +11,9 @@ public class Recipient extends BaseEntity {
     private String email;
     @Column(name = "name")
     private String name;
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "recipients_tags",

--- a/src/main/java/dev/joelfrancisco/abp/entities/Report.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/Report.java
@@ -10,13 +10,16 @@ public class Report extends BaseEntity {
     @Column(name = "id_report")
     private UUID reportId;
     @ManyToOne
-    @JoinColumn(name = "grupo_id")
+    @JoinColumn(name = "group_id")
     @Nullable
-    private Group grupo;
+    private Group group;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    public Report(UUID reportId, @Nullable Group grupo) {
+    public Report(UUID reportId, @Nullable Group group) {
         this.reportId = reportId;
-        this.grupo = grupo;
+        this.group = group;
     }
 
     protected Report() {
@@ -30,11 +33,11 @@ public class Report extends BaseEntity {
         this.reportId = reportId;
     }
 
-    public Group getGrupo() {
-        return grupo;
+    public Group getGroup() {
+        return group;
     }
 
-    public void setGrupo(Group grupo) {
-        this.grupo = grupo;
+    public void setGroup(Group group) {
+        this.group = group;
     }
 }

--- a/src/main/java/dev/joelfrancisco/abp/entities/Report.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/Report.java
@@ -1,0 +1,40 @@
+package dev.joelfrancisco.abp.entities;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+public class Report extends BaseEntity {
+    @Column(name = "id_report")
+    private UUID reportId;
+    @ManyToOne
+    @JoinColumn(name = "grupo_id")
+    @Nullable
+    private Group grupo;
+
+    public Report(UUID reportId, @Nullable Group grupo) {
+        this.reportId = reportId;
+        this.grupo = grupo;
+    }
+
+    protected Report() {
+    }
+
+    public UUID getReportId() {
+        return reportId;
+    }
+
+    public void setReportId(UUID reportId) {
+        this.reportId = reportId;
+    }
+
+    public Group getGrupo() {
+        return grupo;
+    }
+
+    public void setGrupo(Group grupo) {
+        this.grupo = grupo;
+    }
+}

--- a/src/main/java/dev/joelfrancisco/abp/entities/SentEmail.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/SentEmail.java
@@ -2,6 +2,7 @@ package dev.joelfrancisco.abp.entities;
 
 import dev.joelfrancisco.abp.valueObjects.Email;
 import dev.joelfrancisco.abp.valueObjects.EmailStatus;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 
 import java.util.Objects;
@@ -17,6 +18,10 @@ public class SentEmail extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "template_id")
     private Template template;
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    @Nullable
+    private Group group;
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
@@ -64,9 +69,19 @@ public class SentEmail extends BaseEntity {
         this.recipient = Objects.requireNonNull(recipient, "recipient should not be null");
     }
 
-    public SentEmail(Email senderEmail, Template template, User user, Recipient recipient) {
+    @Nullable
+    public Group getGroup() {
+        return group;
+    }
+
+    public void setGroup(@Nullable Group group) {
+        this.group = group;
+    }
+
+    public SentEmail(Email senderEmail, EmailStatus status, Template template, @Nullable Group group, User user, Recipient recipient) {
         setSenderEmail(senderEmail);
         setTemplate(template);
+        setGroup(group);
         setUser(user);
         setRecipient(recipient);
         setStatus(EmailStatus.PROCESSING);

--- a/src/main/java/dev/joelfrancisco/abp/entities/Template.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/Template.java
@@ -7,7 +7,7 @@ import java.util.*;
 @Entity
 public class Template extends BaseEntity {
     @Column(name = "id_template")
-    private UUID template_id;
+    private UUID templateId;
     @Column(name = "version")
     private int version;
     @Column(name = "name")
@@ -79,12 +79,12 @@ public class Template extends BaseEntity {
         this.user = Objects.requireNonNull(user, "user should not be null");
     }
 
-    public UUID getTemplate_id() {
-        return template_id;
+    public UUID getTemplateId() {
+        return templateId;
     }
 
-    public void setTemplate_id(UUID template_id) {
-        this.template_id = template_id;
+    public void setTemplateId(UUID templateId) {
+        this.templateId = templateId;
     }
 
     public int getVersion() {

--- a/src/main/java/dev/joelfrancisco/abp/entities/User.java
+++ b/src/main/java/dev/joelfrancisco/abp/entities/User.java
@@ -26,6 +26,10 @@ public class User extends BaseEntity {
     private Set<SentEmail> sentEmails = new HashSet<>();
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private Set<Template> templates = new HashSet<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private Set<Group> groups = new HashSet<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private Set<Report> reports = new HashSet<>();
 
     private static User newUser(String username, UserPassword passwordHash, String name, Set<EmailCredentials> credentials) throws UserCreationException {
         User user = new User();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 # Configurações do banco de dados SQL Server
-spring.datasource.url=http://localhost:5432
-spring.datasource.username=myuser
-spring.datasource.password=secret
+# spring.datasource.url=http://localhost:5432
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=Pos@1234
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC


### PR DESCRIPTION
Will take one endpoint to create our reports view:

`/report` to generates and send to the user a PDF file with all individual emails sent in the last week

- When a Group body is sent, only emails sent for the group_id will be reported

I think we can make it obligatory to create a group before sending emails. It's an mail marketing app so a group for multiple recipients can be a required thing. Maybe a business rule 👀 

I've thought about building them like [this](https://prnt.sc/5PVzobaFFyI5)